### PR TITLE
Add: 영상연결 기능 추가

### DIFF
--- a/src/screens/VideoScreen/index.tsx
+++ b/src/screens/VideoScreen/index.tsx
@@ -50,10 +50,9 @@ const Video = () => {
 
   useEffect(() => {
     socket.current.onopen = () => {
-      console.log('connection');
+      sendToServer({type: 'join-room', roomID, username});
+      console.log('connected and joined the room.');
     };
-
-    sendToServer({type: 'join-room', roomID, username});
 
     socket.current.onmessage = msg => {
       const data = JSON.parse(msg.data);


### PR DESCRIPTION
### PR Type
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 기타 (기타인 경우 내용 입력 :  ) 

### 해당 PR의 목적
- 영상연결을 위한 WebRTC 기능 코드 작성

### 해당 PR 사유
- 영상연결 기능 추가

### 리뷰어가 중점적으로 봤으면 하는 부분
- 1. useEffect를 세 번 사용하여 아래와 같이 처리해 주었는데, 이슈 없을지 확인 부탁드립니다!
		1)내 stream가져오기 2) 내 stream 추가 및 상대의 stream가져오기 3) 서버로부터 받는 메세지에 따른 함수 작성
- 2. 영상 채팅 시작 시에 `두 유저가 최초로 연결될 때의 상황을 어떻게 처리`해야 할 지 여쭙습니다.
		제가 이해하기로는 구글미팅같은 영상연결 서비스는 누군가가 방을 만들어 방 주소를 공유하면 둘이 같은 방에 입장하는 형태인데요, 
		현재 기획화면 상 '영상연결'버튼을 누르는 것만 있어, 두 명의 유저가 어떻게 연결되어야 하는가에 대한 부분에서 막혀있는 상황입니다.
		현재 작성한 코드 상으로는 유저가 서버로부터 `welcome이란 메세지를 받으면 본인에게 온 offer가 없다는 의미이기에, 전화를 걸어라`라는 로직으로 구현했습니다. 그러나 애초에 `본인에게 온 offer가 있는지 없는지를 서버가 어떻게 알 수 있는지`가 궁금합니다.
		
